### PR TITLE
Add leagueUrl to API

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ type Match = {
   hash: string
   teams: [Team | null, Team | null]
   matchType: string | null
-  startsAt: Date | null
+  startsAt: string | null
   leagueName: string | null
+  leagueUrl: string | null
   streamUrl: string | null
 }
 ```

--- a/src/dota.ts
+++ b/src/dota.ts
@@ -20,6 +20,7 @@ export type Match = {
   matchType: string | null
   startsAt: string | null
   leagueName: string | null
+  leagueUrl: string | null
   streamUrl: string | null
 }
 
@@ -119,12 +120,14 @@ const fetchMatches = async (country: string): Promise<Match[]> => {
       const startTime = meta$.attrs["data-timestamp"]
       const streamName = meta$.attrs["data-stream-twitch"]
       const leagueName = leagueLink$.attrs["title"]
+      const leagueUrl = leagueLink$.attrs["href"]
 
       return await withHash({
         teams,
         matchType: matchType ?? null,
         startsAt: startTime ? new Date(Number(startTime) * 1000).toISOString() : null,
         leagueName,
+        leagueUrl: leagueUrl ? `https://liquipedia.net${leagueUrl}` : null,
         streamUrl: streamName
           ? `https://liquipedia.net/dota2/Special:Stream/twitch/${streamName}`
           : null,

--- a/src/fixtures/matches.json
+++ b/src/fixtures/matches.json
@@ -14,6 +14,7 @@
     "matchType": "Bo3",
     "startsAt": "2022-07-31T15:00:00.000Z",
     "leagueName": "Dota 2 Champions League Season 13",
+    "leagueUrl": "https://liquipedia.net/dota2/Dota_2_Champions_League/2022/Season_7",
     "streamUrl": null
   },
   {
@@ -31,6 +32,7 @@
     "matchType": "Bo3",
     "startsAt": "2022-07-31T21:30:00.000Z",
     "leagueName": "ESL One Malaysia 2022 North America: Closed Qualifier",
+    "leagueUrl": "https://liquipedia.net/dota2/ESL_One/Malaysia/2022/North_America/Closed_Qualifier",
     "streamUrl": null
   },
   {
@@ -48,6 +50,7 @@
     "matchType": "Bo2",
     "startsAt": "2022-08-04T15:00:00.000Z",
     "leagueName": "PGL Arlington Major 2022",
+    "leagueUrl": "https://liquipedia.net/dota2/PGL/Arlington_Major/2022",
     "streamUrl": "https://liquipedia.net/dota2/Special:Stream/twitch/PGL_Dota2_EN3"
   }
 ]

--- a/src/notify.test.ts
+++ b/src/notify.test.ts
@@ -6,7 +6,7 @@ import type { MockInterceptor } from "undici/types/mock-interceptor"
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { Guild } from "./discord"
-import { MATCHES_CACHE_KEY, Match } from "./dota"
+import { Match, MATCHES_CACHE_KEY } from "./dota"
 import matchesFixture from "./fixtures/matches.json"
 import { encode } from "./msgpack"
 import { formatMatchToEmbedField, notifier } from "./notify"
@@ -85,6 +85,7 @@ describe("notifier", () => {
         ],
         startsAt: addHours(now, 3).toISOString(),
         leagueName: null,
+        leagueUrl: null,
         streamUrl: null,
       },
       {
@@ -96,6 +97,7 @@ describe("notifier", () => {
         ],
         startsAt: addHours(now, 12).toISOString(),
         leagueName: null,
+        leagueUrl: null,
         streamUrl: null,
       },
       {
@@ -107,6 +109,7 @@ describe("notifier", () => {
         ],
         startsAt: addHours(now, 4.5).toISOString(),
         leagueName: null,
+        leagueUrl: null,
         streamUrl: null,
       },
       {
@@ -118,6 +121,7 @@ describe("notifier", () => {
         ],
         startsAt: addHours(now, 24 * 4).toISOString(),
         leagueName: null,
+        leagueUrl: null,
         streamUrl: null,
       },
     ]
@@ -160,6 +164,7 @@ describe("notifier", () => {
         ],
         startsAt: addHours(now, 22).toISOString(),
         leagueName: null,
+        leagueUrl: null,
         streamUrl: null,
       },
       {
@@ -171,6 +176,7 @@ describe("notifier", () => {
         ],
         startsAt: addHours(now, 6).toISOString(),
         leagueName: null,
+        leagueUrl: null,
         streamUrl: null,
       },
       {
@@ -182,6 +188,7 @@ describe("notifier", () => {
         ],
         startsAt: addHours(now, 12).toISOString(),
         leagueName: null,
+        leagueUrl: null,
         streamUrl: null,
       },
     ]


### PR DESCRIPTION
Closes https://github.com/BeeeQueue/dota-matches-api/issues/55

How has this been tested:

1. Locally ran `pnpm dev`
2. GET http://172.18.93.216:8787/v1/matches
3. Checked that `leagueUrl` is in the response while other key remains the same
