### PR TITLE
Encode URL Data To Proper URLs

### DIFF
--- a/src/dota.ts
+++ b/src/dota.ts
@@ -127,9 +127,9 @@ const fetchMatches = async (country: string): Promise<Match[]> => {
         matchType: matchType ?? null,
         startsAt: startTime ? new Date(Number(startTime) * 1000).toISOString() : null,
         leagueName,
-        leagueUrl: leagueUrl ? `https://liquipedia.net${leagueUrl}` : null,
+        leagueUrl: leagueUrl ? encodeURI(`https://liquipedia.net${leagueUrl}`) : null,
         streamUrl: streamName
-          ? `https://liquipedia.net/dota2/Special:Stream/twitch/${streamName}`
+          ? encodeURI(`https://liquipedia.net/dota2/Special:Stream/twitch/${streamName}`)
           : null,
       })
     }),

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -8,7 +8,7 @@ kv_namespaces = [{ binding = "CACHE", id = "36fe05a650434c41943c782672f104b4" }]
 r2_buckets = [{ binding = "WEBHOOKS", bucket_name = "dota-matches-webhooks" }]
 
 [miniflare]
-kv_persist = true
+#kv_persist = true
 r2_persist = true
 
 [vars]


### PR DESCRIPTION
Some of the stream names have spaces in them causing the built URLs to be invalid.